### PR TITLE
Fix path matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Denne tjenesten tilgjengeliggjør de aktuelle APIene som trenger å nås utenfra
 
 # Tjenester det redirectes til
 
-| Tjeneste              | Path                   | Scope                             |
-|-----------------------|------------------------|-----------------------------------|
-| Yrkesskademelding API | /api/v1/skademeldinger | nav:yrkesskade:skademelding.write |
-| Yrkesskade kodeverk   | /api/v1/kodeverk/**    | nav:yrkesskade:kodeverk.read      |
+| Tjeneste                    | Path                           | Scope                             |
+|-----------------------------|--------------------------------|-----------------------------------|
+| Yrkesskademelding API       | /api/v1/skademeldinger         | nav:yrkesskade:skademelding.write |
+| Yrkesskademelding API-doc   | /api/v1/skademeldinger/api-doc | N/A                               |
+| Yrkesskade kodeverk         | /api/v1/kodeverk/**            | nav:yrkesskade:kodeverk.read      |
+| Yrkesskade kodeverk API-doc | /api/v1/kodeverk/api-doc       | N/A                               |
 
 # Miljøer
 | miljø | URL                                                   |

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,18 +10,22 @@ spring:
         - id: yrkesskade-melding-api
           uri: ${YRKESSKADE_MELDING_API}
           predicates:
-            - Path=/api/v1/skademeldinger,/api/v3/**,/api/swagger-ui/**
+            - Path=/api/v1/skademeldinger/**
+          filters:
+            - RewritePath=/api/v1/skademeldinger/api-doc, /api/v3/api-docs
         - id: yrkesskade-kodeverk
           uri: ${YRKESSKADE_KODEVERK}
           predicates:
             - Path=/api/v1/kodeverk/**
+          filters:
+            - RewritePath=/api/v1/kodeverk/api-doc, /v3/api-docs
 
 token:
   validation:
     scopes:
       yrkesskade-melding-api:
         - name: "nav:yrkesskade:skademelding.write"
-          path: /api/v1/skademeldinger
+          path: /api/v1/skademeldinger/**
         - name: "noscope.apidoc"
           path: /api/v3/**
         - name: "noscope.swaggerui"
@@ -29,6 +33,10 @@ token:
       yrkesskade-kodeverk:
         - name: "nav:yrkesskade:kodeverk.read"
           path: /api/v1/kodeverk/**
+        - name: "noscope.apidoc"
+          path: /v3/api-docs
+        - name: "noscope.swaggerui"
+          path: /api/swagger-ui/**
   tokenx:
     client-list:
       - yrkesskade-melding-api


### PR DESCRIPTION
- La api/v1/{tjeneste}/api-doc føre til {tjeneste} sin respektive api-doc (skademelding tok presedens tidligere)
- Åpne for kodeverk-apidoc i scope-validering
- Justere path for skademeldinger i scope-valideringen for å støtte trailing slash
- Oppdatere README.md